### PR TITLE
Fix segmentation fault for agl release build mode.

### DIFF
--- a/platforms/agl/alexa-voiceagent-service/src/plugins/afb/AFBApiImpl.cpp
+++ b/platforms/agl/alexa-voiceagent-service/src/plugins/afb/AFBApiImpl.cpp
@@ -77,6 +77,8 @@ int AFBApiImpl::callSync(
         info = infoStr;
         free(infoStr);
     }
+
+    return rc;
 }
 
 /// Shim to transfer C++ function to C callback using void*


### PR DESCRIPTION
'int IAFBApi::callSync(...)' is missing a return
statement. When the sdk is compiled in release mode
executing this code results in a segmentation fault.

Signed-off-by: Raquel Medina <raquel.medina@konsulko.com>

*Issue #, if available:*
This issue was raised in Automotive Grade Linux jira
as SPEC-2873.
The fix has been tested against AGL master and
happy halibut (8.0.2) branches.

*Description of changes:*
According to the C++ standard, a return statement is
required on a function that returns a non-void value.
Specifically: <<Flowing off the end of a function is
equivalent to a return with no value; this results in
undefined behaviour in a value-returning function.>>

The proposed fix provides the missing return statement
for IAFBApi's callSync method.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
