### PR TITLE
Avoid meaningless project name

### DIFF
--- a/samples/android/settings.gradle
+++ b/samples/android/settings.gradle
@@ -1,1 +1,2 @@
+rootProject.name = "Alexa-auto-sdk"
 include ':app', ':modules:sample-core'


### PR DESCRIPTION
It's about to avoid a meaningless project name, when you have several projects open

![image](https://user-images.githubusercontent.com/3314607/79421319-d60c5b00-7fba-11ea-9100-48dbec4a5bed.png)
