### PR TITLE
Fix doc

### DIFF
--- a/samples/android/README.md
+++ b/samples/android/README.md
@@ -81,7 +81,7 @@ The pre-built platform AARs for the default Auto SDK modules and the core-sample
 The Sample App builder scripts are configured to use JCenter to always pull the latest release artifacts during compilation. To run the builder scripts, issue the following command:
 
 ```
-$ gradle assembleRemoteRelease
+$ ./gradlew assembleRemoteRelease
 ```
 
 Alternatively, you can manually download the platform AARs and core-sample AAR from the [JCenter repo](https://jcenter.bintray.com/com/amazon/alexa/aace/) to
@@ -104,7 +104,7 @@ If you do not use the pre-built platform AARs and core-sample AAR, you must buil
 Once you have generated the platform AARs and the core-sample AAR, issue the following command to run the builder scripts:
 
 ``` 
-$ gradle assembleLocalRelease
+$ ./gradlew assembleLocalRelease
 ```
 Alternatively, you can follow the steps to [configure the project in Android Studio](#configure-the-project-in-android-studio).
 


### PR DESCRIPTION
_**Issue**_
Building does not work
```
FAILURE: Build failed with an exception.

* What went wrong:
Task 'assembleRemoteRelease' not found in root project 'alexa-auto-sdk'.

* Try:
Run gradle tasks to get a list of available tasks. Run with --stacktrace option to get the stack trace. Run with --info or --debug option to get more log output. Run with --scan to get full insights.

* Get more help at https://help.gradle.org

BUILD FAILED in 510ms

```

***Description of changes:***
Use project gradle distro
