### PR TITLE
Fix re-authentication not working after logout

### DIFF
--- a/modules/cbl/engine/src/CBLAuthorizationProvider.cpp
+++ b/modules/cbl/engine/src/CBLAuthorizationProvider.cpp
@@ -974,6 +974,11 @@ CBLAuthorizationProvider::FlowState CBLAuthorizationProvider::handleStopping() {
 
     std::lock_guard<std::mutex> lock(m_mutex);
     m_isStopping = true;
+
+    // Reset token related variables for a possible re-authentication
+    m_timeToRefresh = std::chrono::steady_clock::now();
+    m_tokenExpirationTime = std::chrono::steady_clock::time_point::max();
+
     return FlowState::STOPPING;
 }
 


### PR DESCRIPTION
It is not possible to re-authenticate a user with
a previous refresh token without stopping/starting AACS.

To avoid going trough the whole CBL process again we might
save the refresh token to speed up the authorization process.

However, after logging out and starting the authentication
process again the CBLAuthorizationProvider gets stuck on
the REFRESHING_TOKEN state.

This is because we don't reset the m_timeToRefresh variable
after stopping a previous authorization process.
That way the new authorization will be blocked until
that time expires.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
