### PR TITLE
Play audio with the correct usage and type

### DIFF
--- a/platforms/android/alexa-auto-client-service/android-service/service/src/main/java/com/amazon/alexaautoclientservice/mediaPlayer/exo/ExoPlayerHandler.java
+++ b/platforms/android/alexa-auto-client-service/android-service/service/src/main/java/com/amazon/alexaautoclientservice/mediaPlayer/exo/ExoPlayerHandler.java
@@ -122,8 +122,15 @@ public class ExoPlayerHandler implements AACSMediaPlayer, AudioManager.OnAudioFo
     }
 
     private void initializePlayer() {
+
+        com.google.android.exoplayer2.audio.AudioAttributes audioAttributes = 
+            new com.google.android.exoplayer2.audio.AudioAttributes.Builder()
+                .setContentType(mAudioFocusAttributes.mContentType)
+                .setUsage(mAudioFocusAttributes.mUsage).build();
+
         mPlayer = new SimpleExoPlayer.Builder(mContext).build();
         mPlayer.addListener(new PlayerEventListener());
+        mPlayer.setAudioAttributes(audioAttributes, false);
         mPlayer.setPlayWhenReady(false);
     }
 


### PR DESCRIPTION
When speaking Alexa request audio focus
with USAGE_ASSISTANT and CONTENT_TYPE_SPEECH
but the audio is played in the USAGE_MEDIA
channel.

This is because we don't set the AudioAttributes
to the SimpleExoPlayer instance built for the
intended purpose.

Signed-off-by: Rafael Chagas <rafael.chagas@volvo.com>

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
