### PR TITLE
Accept null playback controls when Alexa sings

### DIFF
--- a/platforms/android/alexa-auto-client-service/commonutils/aacscommonutils/src/main/java/com/amazon/alexa/auto/aacs/common/RenderPlayerInfo.kt
+++ b/platforms/android/alexa-auto-client-service/commonutils/aacscommonutils/src/main/java/com/amazon/alexa/auto/aacs/common/RenderPlayerInfo.kt
@@ -1,5 +1,6 @@
 package com.amazon.alexa.auto.aacs.common
 
+import com.squareup.moshi.Json
 import com.squareup.moshi.JsonClass
 import java.util.*
 
@@ -47,8 +48,12 @@ data class PlaybackControl (
 @JsonClass(generateAdapter = true)
 data class RenderPlayerInfoPayload (
     val content : RenderPlayerContent,
-    val controls : List<PlaybackControl>
-)
+    @Json(name = "controls")
+    val _controls : List<PlaybackControl>?
+) {
+    // Expose non nullable playback controls
+    val controls : List<PlaybackControl> = _controls.orEmpty()
+}
 
 @JsonClass(generateAdapter = true)
 data class RenderPlayerInfo (


### PR DESCRIPTION
The MediaSession is not being updated when Alexa sings.

This is because Moshi crashes when trying to parse
the RenderPlayerInfo.

error: com.squareup.moshi.JsonDataException:
Non-null value 'controls' was null at $.payload.control

AACS expects the 'controls' field of the RenderPlayerInfo
object to be non nullable but this is not the case
when Alexa sings.

{
    "audioItemId": "",
    "content": {
        "art": {
            "contentDescription": "Take Me Out to the Ball Game",
            "sources": [{
                "heightPixels": 0,
                "size": null,
                "url": "https:\/\/d3l071etx9fo2i.cloudfront.net...",
                "widthPixels": 0
            }]
        },
        "background": null,
        "header": null,
        "headerSubtext1": null,
        "mediaLengthInMilliseconds": 0,
        "provider": {
            "logo": {
                "contentDescription": null,
                "sources": [{
                    "heightPixels": null,
                    "size": null,
                    "url": "https:\/\/s3.amazonaws.com\/CAPS-...",
                    "widthPixels": null
                }]
            },
            "name": "Greetings"
        },
        "title": "Take Me Out to the Ball Game",
        "titleSubtext1": "Alexa",
        "titleSubtext2": "Greetings"
    },
    "controls": null
}

Signed-off-by: Rafael Chagas <rafael.chagas@volvo.com>

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
