### PR TITLE
Set java compatibility to 1.8 in aacs maccandroid

### DIFF
--- a/aacs/android/service/modules/maccandroid/build.gradle
+++ b/aacs/android/service/modules/maccandroid/build.gradle
@@ -31,6 +31,10 @@ android {
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
 
     }
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
+    }
     buildTypes {
         release {
             minifyEnabled false


### PR DESCRIPTION
Follow the docs to build aacs android services, running:

./gradlew assembleLocalRelease

This causes error to compile (because no source was defined): maccandroid/MediaAppsDirectivesHandler.java:91: error: lambda expressions are not supported in -source 7
                    mMainThreadDirectivesHandler.post(() -> mediaApp.connect(MediaAppsDirectivesHandler.this));
                                                         ^
  (use -source 8 or higher to enable lambda expressions)
1 error