### PR TITLE
Fix example JSON to enable media ducking

### DIFF
--- a/aacs/android/app-components/alexa-auto-media-player/README.md
+++ b/aacs/android/app-components/alexa-auto-media-player/README.md
@@ -34,9 +34,11 @@ You can enable audio ducking for the Alexa media using this configuration. By de
 ```JSON
 {
     "aacs.alexa" : {
-        "audioOutputType.music": {
-            "ducking": {
-                "enabled" : true
+        "audio": {
+            "audioOutputType.music": {
+                "ducking": {
+                    "enabled": true
+                }
             }
         }
     }


### PR DESCRIPTION
Example snippet is incorrect, missing the `audio` object.
