### PR TITLE
Remove notification listener permission check in LocalSessionHandler

### DIFF
--- a/aacs/android/service/core-service/src/main/java/com/amazon/alexaautoclientservice/modules/mediaManager/LocalSessionHandler.java
+++ b/aacs/android/service/core-service/src/main/java/com/amazon/alexaautoclientservice/modules/mediaManager/LocalSessionHandler.java
@@ -44,11 +44,6 @@ public class LocalSessionHandler {
     }
 
     public void onCreate(Context context) {
-        if (!NotificationListener.isEnabled(context)) {
-            Log.w(TAG,
-                    "Notification Listener permission is required for this feature to work, please provide the permission and restart the app to use Local Media Source controlling through Alexa");
-            return;
-        }
         mMediaSessionManager = (MediaSessionManager) context.getSystemService(Context.MEDIA_SESSION_SERVICE);
         if (mMediaSessionManager == null) {
             Log.w(TAG, "MediaSessionManager is null, something went wrong");


### PR DESCRIPTION
There is no need for this permission if MEDIA_CONTENT_CONTROL is granted. The correct check is already done in AlexaAutoClientService.java (for both MEDIA_CONTENT_CONTROL and notification listener permission).
