### PR TITLE
Fix Alexa TTS crash when using MP3 decoder

### DIFF
--- a/aacs/android/app-components/alexa-auto-tts/aacstts/src/main/java/com/amazon/aacstts/AmazonTextToSpeechService.java
+++ b/aacs/android/app-components/alexa-auto-tts/aacstts/src/main/java/com/amazon/aacstts/AmazonTextToSpeechService.java
@@ -163,17 +163,7 @@ public class AmazonTextToSpeechService extends TextToSpeechService {
     protected int onLoadLanguage(String lang, String country, String variant) {
         Log.d(TAG, "onLoadLanguage");
 
-        // Load the capabilities of the TextToSpeech and
-        // update the cache with the supported languages.
-        GetCapabilitiesPayload getCapabilitiesPayload = new GetCapabilitiesPayload();
-        getCapabilitiesPayload.setProvider(DEFAULT_PROVIDER);
-
-        Optional<String> message = AACSMessageBuilder.buildMessage(
-                TTSConstants.TOPIC, TTSConstants.Action.GET_CAPABILITIES, getCapabilitiesPayload.toJsonString());
-
-        if (message.isPresent()) {
-            sendMessageToAACS(message.get(), TTSConstants.Action.GET_CAPABILITIES, TTSConstants.TOPIC);
-        }
+        sendGetCapabilitiesMessageToAACS();
 
         if (onIsLanguageAvailable(lang, country, variant) == TextToSpeech.LANG_COUNTRY_AVAILABLE) {
             return TextToSpeech.LANG_COUNTRY_AVAILABLE;
@@ -305,7 +295,7 @@ public class AmazonTextToSpeechService extends TextToSpeechService {
             return;
         }
         mMessageHandler = new MessageHandler();
-        mMessageHandler.register(Topic.ALEXA_CLIENT, mAlexaClientHandler = new AlexaClientHandler())
+        mMessageHandler.register(Topic.ALEXA_CLIENT, mAlexaClientHandler = new AlexaClientHandler(this::sendGetCapabilitiesMessageToAACS))
                 .register(Topic.AASB, mAASBHandler = new AASBHandler())
                 .register(TTSConstants.TOPIC, mTTSHandler = new TTSHandler(mSynthesizeTextUtil));
     }
@@ -335,6 +325,21 @@ public class AmazonTextToSpeechService extends TextToSpeechService {
                                 e.getMessage(), topic, action));
             }
         });
+    }
+
+    private void sendGetCapabilitiesMessageToAACS() {
+        // Load the capabilities of the TextToSpeech and
+        // update the cache with the supported languages.
+        GetCapabilitiesPayload getCapabilitiesPayload = new GetCapabilitiesPayload();
+        getCapabilitiesPayload.setProvider(DEFAULT_PROVIDER);
+
+        Optional<String> message = AACSMessageBuilder.buildMessage(
+                TTSConstants.TOPIC, TTSConstants.Action.GET_CAPABILITIES, getCapabilitiesPayload.toJsonString());
+
+        if (message.isPresent()) {
+            sendMessageToAACS(message.get(), TTSConstants.Action.GET_CAPABILITIES, TTSConstants.TOPIC);
+        }
+
     }
 
     private Optional<ProviderVoiceItem> getVoiceItem(String locale) {

--- a/aacs/android/app-components/alexa-auto-tts/aacstts/src/main/java/com/amazon/aacstts/AudioDecoder.java
+++ b/aacs/android/app-components/alexa-auto-tts/aacstts/src/main/java/com/amazon/aacstts/AudioDecoder.java
@@ -94,23 +94,23 @@ public class AudioDecoder {
         if (inputData.length % BITS_IN_A_BYTE != 0)
             return null;
 
-        while (true) {
-            /*
-             * Loading the input data into the input buffers.
-             */
-            int inputBufferIndex = mDecoder.dequeueInputBuffer(TIMEOUT_IN_MICROSECONDS);
-            if (inputBufferIndex >= 0) {
-                mDecoder.getInputBuffer(inputBufferIndex).put(inputData);
-                if (bytesToDecode < 0) {
-                    mDecoder.queueInputBuffer(inputBufferIndex, 0, 0, 0, BUFFER_FLAG_END_OF_STREAM);
-                } else {
-                    int presentationTime = 0; // Only required if we are synchronizing audio and video.
-                    mDecoder.queueInputBuffer(inputBufferIndex, 0, bytesToDecode, presentationTime, 0);
-                }
+        /*
+         * Loading the input data into the input buffers.
+         */
+        int inputBufferIndex = mDecoder.dequeueInputBuffer(TIMEOUT_IN_MICROSECONDS);
+        if (inputBufferIndex >= 0) {
+            mDecoder.getInputBuffer(inputBufferIndex).put(inputData);
+            if (bytesToDecode < 0) {
+                mDecoder.queueInputBuffer(inputBufferIndex, 0, 0, 0, BUFFER_FLAG_END_OF_STREAM);
             } else {
-                Log.e(TAG, "Input Buffer is not available");
+                int presentationTime = 0; // Only required if we are synchronizing audio and video.
+                mDecoder.queueInputBuffer(inputBufferIndex, 0, bytesToDecode, presentationTime, 0);
             }
+        } else {
+            Log.e(TAG, "Input Buffer is not available");
+        }
 
+        while (true) {
             /*
              * Checking if output buffers are ready with the decoded data
              * and returning when they are ready

--- a/aacs/android/app-components/alexa-auto-tts/aacstts/src/main/java/com/amazon/aacstts/handler/AlexaClientHandler.java
+++ b/aacs/android/app-components/alexa-auto-tts/aacstts/src/main/java/com/amazon/aacstts/handler/AlexaClientHandler.java
@@ -32,6 +32,14 @@ import java.util.Optional;
  * with {@link com.amazon.aacstts.MessageHandler} and is used for handling messages with AlexaClient topic.
  */
 public class AlexaClientHandler implements IAACSMessageHandler {
+    public interface onAlexaClientConnectionStatusChangedCallback {
+        public void onAlexaClientConnected();
+    }
+    private onAlexaClientConnectionStatusChangedCallback mAlexaClientConnectionStatusChangedCallback;
+    public AlexaClientHandler(onAlexaClientConnectionStatusChangedCallback callback) {
+        mAlexaClientConnectionStatusChangedCallback = callback;
+    }
+
     private static final String TAG = AACS_TTS_LOG_PREFIX + AlexaClientHandler.class.getSimpleName();
     private Optional<Boolean> mIsAlexaClientConnected = Optional.empty();
 
@@ -70,6 +78,7 @@ public class AlexaClientHandler implements IAACSMessageHandler {
         switch (status) {
             case AASBConstants.AlexaClient.ALEXA_CLIENT_STATUS_CONNECTED:
                 mIsAlexaClientConnected = Optional.of(true);
+                mAlexaClientConnectionStatusChangedCallback.onAlexaClientConnected();
                 break;
             default:
                 mIsAlexaClientConnected = Optional.of(false);


### PR DESCRIPTION
Fix a couple of issues with the Alexa TTS:
* Fix `IllegalStateException` crash in the AmazonTextToSpeechService: the mp3 decoder can go out of sync if it receives partial frames, leading to a crash of the TTS service. Always ensure that we send full frames to the decoder.
* Fix failing first synthesis request, caused by the service not loading language capabilities when connected to Alexa.